### PR TITLE
fix: pg overwriting data if not mounted correct

### DIFF
--- a/charts/postgres/templates/statefulset.yaml
+++ b/charts/postgres/templates/statefulset.yaml
@@ -39,9 +39,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-secrets
                   key: lldap-password
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
           volumeMounts:
             - name: postgres-pv-storage
-              mountPath: /var/lib/postgresql
+              mountPath: /var/lib/postgresql/data
             - name: init-scripts
               mountPath: /docker-entrypoint-initdb.d
       volumes:


### PR DESCRIPTION
Fixes a bug where pg recreated its data volume on restart. Make sure to run pg-backup before and pg-restore after deploy.